### PR TITLE
Configurable torch color and SOS from pulley

### DIFF
--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -136,40 +136,44 @@ Page {
         torchRectangle.color = "white";
     }
 
-    Rectangle{
-        id: torchRectangle
+    SilicaFlickable {
         anchors.fill: parent
-        color: "white"
 
-        MouseArea {
+        PullDownMenu{
+            MenuItem {
+                 text: qsTr("Toggle morseing SOS")
+                 onClicked: toggleTimer()
+             }
+        }
+
+        Rectangle{
+            id: torchRectangle
             anchors.fill: parent
-            onClicked: {
-//                console.debug("tapped...");
-                toggleTimer();
+            color: "white"
+
+            BusyIndicator {
+                id: torchBusyIndicator
+                anchors.centerIn: parent
+                size: BusyIndicatorSize.Large
+                running: false
+            }
+            Label {
+                id: torchAboutToStartText
+                visible: false
+                anchors.bottom: torchBusyIndicator.top
+                anchors.bottomMargin: Theme.paddingLarge
+                anchors.left: parent.left
+                anchors.right: parent.right
+                horizontalAlignment: Text.AlignHCenter
+                wrapMode: Text.WordWrap
+                color: Theme.highlightColor
+                font.family: Theme.fontFamilyHeading
+                font.pixelSize: Theme.fontSizeExtraLarge
+                text: "SOS blinking starts\nin " + morseGapLetter/1000  + "s"
             }
         }
-        BusyIndicator {
-            id: torchBusyIndicator
-            anchors.centerIn: parent
-            size: BusyIndicatorSize.Large
-            running: false
+        SimpleTorchScreenBlank{
+            activated: Qt.application.active
         }
-        Label {
-            id: torchAboutToStartText
-            visible: false
-            anchors.bottom: torchBusyIndicator.top
-            anchors.bottomMargin: Theme.paddingLarge
-            anchors.left: parent.left
-            anchors.right: parent.right
-            horizontalAlignment: Text.AlignHCenter
-            wrapMode: Text.WordWrap
-            color: Theme.highlightColor
-            font.family: Theme.fontFamilyHeading
-            font.pixelSize: Theme.fontSizeExtraLarge
-            text: "SOS blinking starts\nin " + morseGapLetter/1000  + "s"
-        }
-    }
-    SimpleTorchScreenBlank{
-        activated: Qt.application.active
     }
 }

--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -91,7 +91,7 @@ Page {
             if (torchRectangle.color != "#000000") {
                 torchRectangle.color = "black";
             } else if (torchRectangle.color == "#000000"){
-                torchRectangle.color = torchColor
+                torchRectangle.color = "white"
             }
             switch(morseCounter)
             {


### PR DESCRIPTION
1. toggling the SOS morse code is moved to a pull down menu. Rational behind this: SOS morse is a rare use case, but triggering it is extremely easy and in most cases undesired. Tapping it is just to easy, especially with narrow bezels. 

2. A color picker was introduced with an adapted palette of colours, mainly oriented on natural light sources. My use case here is that I use it as reading light in bed. A less bright color is easier for my eyes (and sleepiness) and less annoying for my wife ;)

3. Initially I had the morse code also in the customized color, but switched it back to white, since it is probably the most reasonable choice for this scenario.